### PR TITLE
make labels more unique, to differentiate

### DIFF
--- a/utils/transformer_tool/examples/glosis_cl/glosis_cl.csv
+++ b/utils/transformer_tool/examples/glosis_cl/glosis_cl.csv
@@ -347,13 +347,13 @@ carbonatesForms,HL,,HL,hard cemented layer or layers of carbonates (less than 10
 carbonatesForms,SC,,SC,soft concretions,,,,False,table 39
 carbonatesForms,D,,D,disperse powdery lim,,,,False,table 39
 carbonatesForms,PM,,PM,"pseudomycelia* (carbonate infillings in pores, resembling mycelia)",,,,False,table 39
-fragmentCover,F,,F,Few,2%–5%,,,False,table 15.1
-fragmentCover,C,,C,Commo,5%–15%,,,False,table 15.1
-fragmentCover,V,,V,Very few,0%–2%,,,False,table 15.1
-fragmentCover,N,,N,No,0%,,,False,table 15.1
-fragmentCover,D,,D,Dominant,> 80%,,,False,table 15.1
-fragmentCover,M,,M,Many,15%–40%,,,False,table 15.1
-fragmentCover,A,,A,Abundant,40%–80%,,,False,table 15.1
+fragmentCover,F,,F,Few fragments,2%–5%,,,False,table 15.1
+fragmentCover,C,,C,Common fragments,5%–15%,,,False,table 15.1
+fragmentCover,V,,V,Very few fragments,0%–2%,,,False,table 15.1
+fragmentCover,N,,N,No fragments,0%,,,False,table 15.1
+fragmentCover,D,,D,Dominant fragments,> 80%,,,False,table 15.1
+fragmentCover,M,,M,Many fragments,15%–40%,,,False,table 15.1
+fragmentCover,A,,A,Abundant fragments,40%–80%,,,False,table 15.1
 landUseClass,PN3,PN,PN3,Wildlife management,,,,False,table 8
 landUseClass,AP2,AP,AP2,Irrigated cultivatio,,,,False,table 8
 landUseClass,AT,A,AT,Tree and shrub cropping,,,,False,table 8
@@ -410,13 +410,13 @@ consistenceMoist,EFI,,EFI,Extremely firm,Soil material crushes only under very s
 consistenceMoist,FR,,FR,Friabl,"Soil material crushes easily under gentle to moderate pressure between thumb and forefinger, and coheres when pressed together.",,,False,table 54
 consistenceMoist,VFR,,VFR,Very friabl,"Soil material crushes under very gentle pressure, but coheres when pressed together.",,,False,table 54
 consistenceMoist,LO,,LO,Loos,Non-coherent.,,,False,table 54
-rockOutcropsCover,M,,M,Many,15–40 4 2–5,,,False,"table 14,1"
-rockOutcropsCover,A,,M,Abundant,40–80 5 < 2,,,False,"table 14,1"
-rockOutcropsCover,F,,F,Few,2–5 2 20–50,,,False,"table 14,1"
-rockOutcropsCover,V,,V,Very few,0–2 1 > 50,,,False,"table 14,1"
-rockOutcropsCover,D,,D,Dominant,> 80,,,False,"table 14,1"
-rockOutcropsCover,N,,N,No,,,,False,"table 14,1"
-rockOutcropsCover,C,,C,Commo,5–15 3 5–20,,,False,"table 14,1"
+rockOutcropsCover,M,,M,Many outcrops,15–40 4 2–5,,,False,"table 14,1"
+rockOutcropsCover,A,,M,Abundant outcrops,40–80 5 < 2,,,False,"table 14,1"
+rockOutcropsCover,F,,F,Few outcrops,2–5 2 20–50,,,False,"table 14,1"
+rockOutcropsCover,V,,V,Very few outcrops,0–2 1 > 50,,,False,"table 14,1"
+rockOutcropsCover,D,,D,Dominant outcrops,> 80,,,False,"table 14,1"
+rockOutcropsCover,N,,N,No outcrops,,,,False,"table 14,1"
+rockOutcropsCover,C,,C,Common outcrops,5–15 3 5–20,,,False,"table 14,1"
 floodFrequency,,,,,,,,,
 bulkDensityMineral,BD2,,BD2,Sample disintegrates into numerous fragments after application of weak pressure.,"Loamy soils with high clay content, clayey soils. When dropped, sample disintegrates into few fragments, further disintegration of subfragments after application of mild pressure.",,,False,table 58
 bulkDensityMineral,BD5,,BD5,"Very large pressure necessary to force knife into the soil, no further disintegration of sample.","Loamy soils with high clay content, clayey soils. Sample remains intact when dropped, no further disintegration after application of very large pressure.",,,False,table 58
@@ -460,13 +460,13 @@ coatingNature,CC,,CC,Calcium carbonat,,,,False,table 66
 coatingNature,CS,,CS,Clay and sesquioxides,,,,False,table 66
 coatingNature,C,,C,Clay,,,,False,table 66
 coatingNature,HC,,HC,"Hypodermic coatings (Hypodermic coatings, as used here, are field-scale features, commonly only expressed as hydromorphic features. Micromorphological hypodermic coatings include non-redox features [Bullock et al., 1985].)",,,,False,table 66
-coatingAbundance,V,,V,Very few,0–2,,,False,table 64
-coatingAbundance,F,,F,Few,2–5,,,False,table 64
-coatingAbundance,D,,D,Dominant,> 80,,,False,table 64
-coatingAbundance,C,,C,Commo,5–15,,,False,table 64
-coatingAbundance,N,,N,No,0,,,False,table 64
-coatingAbundance,M,,M,Many,15–40,,,False,table 64
-coatingAbundance,A,,A,Abundant,40–80,,,False,table 64
+coatingAbundance,V,,V,Very few coating,0–2,,,False,table 64
+coatingAbundance,F,,F,Few coating,2–5,,,False,table 64
+coatingAbundance,D,,D,Dominant coating,> 80,,,False,table 64
+coatingAbundance,C,,C,Common coating,5–15,,,False,table 64
+coatingAbundance,N,,N,No coating,0,,,False,table 64
+coatingAbundance,M,,M,Many coating,15–40,,,False,table 64
+coatingAbundance,A,,A,Abundant coating,40–80,,,False,table 64
 physioChemical,Nittot,,Nittot,Nitrogen (N) - total,,,,True,
 physioChemical,Carorg,,Carorg,Carbon (C) - organic,,,,True,
 physioChemical,Avavol,,Avavol,Available water capacity - volumetric (FC to WP),,,,True,
@@ -739,24 +739,24 @@ boundaryDistinctness,A,,A,Abrupt,0cm–2cm,,,False,table 24.1
 boundaryDistinctness,C,,C,Clear,2cm–5cm,,,False,table 24.1
 boundaryDistinctness,D,,D,Diffus,> 15cm,,,False,table 24.1
 boundaryDistinctness,G,,G,Gradual,5cm–15cm,,,False,table 24.1
-mottlesAbundance,M,,M,Many,15–40,,,False,table 32
-mottlesAbundance,V,,V,Very few,0–2,,,False,table 32
-mottlesAbundance,N,,N,No,0,,,False,table 32
-mottlesAbundance,C,,C,Commo,5–15,,,False,table 32
-mottlesAbundance,F,,F,Few,2–5,,,False,table 32
-mottlesAbundance,A,,A,Abundant,> 40,,,False,table 32
+mottlesAbundance,M,,M,Many mottles,15–40,,,False,table 32
+mottlesAbundance,V,,V,Very few mottles,0–2,,,False,table 32
+mottlesAbundance,N,,N,No mottles,0,,,False,table 32
+mottlesAbundance,C,,C,Common mottles,5–15,,,False,table 32
+mottlesAbundance,F,,F,Few mottles,2–5,,,False,table 32
+mottlesAbundance,A,,A,Abundant mottles,> 40,,,False,table 32
 carbonatesContent,EX,,EX,≈ > 25 Extremely calcareous Extremely strong reaction. Thick foam forms quickly.,,,,False,table 38
 carbonatesContent,SL,,SL,≈ 0–2 Slightly calcareous Audible effervescence but not visible.,,,,False,table 38
 carbonatesContent,N,,N,0 Non-calcareous No detectable visible or audible effervescence.,,,,False,table 38
 carbonatesContent,MO,,MO,≈ 2–10 Moderately calcareous Visible effervescence.,,,,False,table 38
 carbonatesContent,ST,,ST,≈ 10–25 Strongly calcareous Strong visible effervescence. Bubbles form a low foam.,,,,False,table 38
-mineralConcVolume,V,,V,Very few,0–2,,,False,table 73
-mineralConcVolume,A,,A,Abundant,40–80,,,False,table 73
-mineralConcVolume,N,,N,No,0,,,False,table 73
-mineralConcVolume,D,,D,Dominant,> 80,,,False,table 73
-mineralConcVolume,M,,M,Many,15–40,,,False,table 73
-mineralConcVolume,C,,C,Commo,5–15,,,False,table 73
-mineralConcVolume,F,,F,Few,2–5,,,False,table 73
+mineralConcVolume,V,,V,Very few mineral concentrations,0–2,,,False,table 73
+mineralConcVolume,A,,A,Abundant mineral concentrations,40–80,,,False,table 73
+mineralConcVolume,N,,N,No mineral concentrations,0,,,False,table 73
+mineralConcVolume,D,,D,Dominant mineral concentrations,> 80,,,False,table 73
+mineralConcVolume,M,,M,Many mineral concentrations,15–40,,,False,table 73
+mineralConcVolume,C,,C,Common mineral concentrations,5–15,,,False,table 73
+mineralConcVolume,F,,F,Few mineral concentrations,2–5,,,False,table 73
 mineralConcNature,NK,,NK,Not know,,,,False,table 77
 mineralConcNature,C,,C,Clay (argillaceous),,,,False,table 77
 mineralConcNature,JA,,JA,Jarosit,,,,False,table 77
@@ -896,14 +896,14 @@ structureGrade,WM,,WM,Weak to moderat,Weak to moderate,,,False,table 47
 structureGrade,MO,,MO,Moderat,"Aggregates are observable in place and there is a distinct arrangement of natural surfaces of weakness. When disturbed, the soil material breaks into a mixture of many entire aggregates, some broken aggregates, and little material without aggregates faces. Aggregates surfaces generally show distinct differences with the aggregates interiors.",,,False,table 47
 structureGrade,ST,,ST,Strong,"Aggregates are clearly observable in place and there is a prominent arrangement of natural surfaces of weakness. When disturbed, the soil material separates mainly into entire aggregates. Aggregates surfaces generally differ markedly from aggregate interiors.",,,False,table 47
 structureGrade,WE,,WE,Weak,"Aggregates are barely observable in place and there is only a weak arrangement of natural surfaces of weakness. When gently disturbed, the soil material breaks into a mixture of few entire aggregates, many broken aggregates, and much material without aggregate faces. Aggregate surfaces differ in some way from the aggregate interior.",,,False,table 47
-rockAbundance,C,,C,Commo,5%–15%,,,False,table 26
-rockAbundance,A,,A,Abundant,40%–80%,,,False,table 26
-rockAbundance,D,,D,Dominant,> 80%,,,False,table 26
-rockAbundance,V,,V,Very few,0%–2%,,,False,table 26
-rockAbundance,N,,N,No,0%,,,False,table 26
-rockAbundance,S,,S,Stone li,"any content, but concentrated at a distinct depth of a horizon",,,False,table 26
-rockAbundance,F,,F,Few,2%–5%,,,False,table 26
-rockAbundance,M,,M,Many,15%–40%,,,False,table 26
+rockAbundance,C,,C,Common rocks,5%–15%,,,False,table 26
+rockAbundance,A,,A,Abundant rocks,40%–80%,,,False,table 26
+rockAbundance,D,,D,Dominant rocks,> 80%,,,False,table 26
+rockAbundance,V,,V,Very few rocks,0%–2%,,,False,table 26
+rockAbundance,N,,N,No rocks,0%,,,False,table 26
+rockAbundance,S,,S,Stone line,"any content, but concentrated at a distinct depth of a horizon",,,False,table 26
+rockAbundance,F,,F,Few rocks,2%–5%,,,False,table 26
+rockAbundance,M,,M,Many rocks,15%–40%,,,False,table 26
 porosityClass,1,,1,Very low,< 2,,,False,table 60
 porosityClass,4,,4,High,15–40,,,False,table 60
 porosityClass,3,,3,Medium,5–15,,,False,table 60


### PR DESCRIPTION
this PR aims to start discussion on differentiation in labels, in this case triggered by display in [skosmos](https://skosmos.org/), where in a default setup a series of abundant labels is displayed

![image](https://user-images.githubusercontent.com/299829/228239730-e4abb9fc-3afd-485b-be01-f0ab4c76fad7.png)

- Is this a common approach in semweb?
- do the current labels reflect properly the meaning, or should I include full object name, eg `abundant rocks` vs `abundant rock coverage`

also fixes some issues of incorrect labels (`stone li`, `commo`)